### PR TITLE
Feature/better ga

### DIFF
--- a/boolmore/genetic_algorithm.py
+++ b/boolmore/genetic_algorithm.py
@@ -307,7 +307,6 @@ def ga_main(start:Model, exps:list[ExpType], fixes_list:list[FixesType],
     
     ### Second to last iterations ###
     for i in range(2,total_iter+1):
-        print("- - - - - iteration ", i, " - - - - -")
         new_iteration = []
         # keep the good ones
         for j in range(keep):

--- a/boolmore/genetic_algorithm.py
+++ b/boolmore/genetic_algorithm.py
@@ -13,8 +13,8 @@ from joblib import Parallel, delayed
 FixesType = tuple[tuple[str, int]]
 ExpType = tuple[int, float, FixesType, str, str]
 
-JSON = "../case_study/data/ABA_2017.json"
-START_MODEL = "../case_study/generated_models/ABA_GA_base_A.txt"
+JSON = "boolmore/case_study/data/ABA_2017.json"
+START_MODEL = "boolmore/case_study/baseline_models/ABA_GA_base_A.txt"
 RUN_NAME = "test"
 DATA = None
 BASE = None
@@ -77,7 +77,7 @@ def run_ga(json_file:str|None=None, start_model:str|None=None, run_name:str|None
         TOTAL_ITERATIONS = 100
         PER_ITERATION = 100
         KEEP = 20
-        MIX = None
+        MIX = 0
         PROB = 0.01
         EDGE_PROB = 0.5
         EXPORT_TOP = 0
@@ -199,7 +199,7 @@ def run_ga(json_file:str|None=None, start_model:str|None=None, run_name:str|None
     return base, start, final
 
 def ga_main(start:Model, exps:list[ExpType], fixes_list:list[FixesType],
-            total_iter:int=100, per_iter:int=100, keep:int=20, mix:int|None=None,
+            total_iter:int=100, per_iter:int=100, keep:int=20, mix:int=0,
             prob:float|list[float]=0.01, edge_prob:float=0.5,
             export_top:int=0, export_thresh:float=0.0, export_name:str|None=None,
             stop_if_max:bool=True, core:int=2
@@ -226,7 +226,7 @@ def ga_main(start:Model, exps:list[ExpType], fixes_list:list[FixesType],
     total_iter - total number of iterations, default 100                :int
     per_iter   - models per iterations, default 100                     :int
     keep       - models to carry over tot he next iteration, default 20 :int
-    mix        - number of models to mix from the keep, default keep    :int|None
+    mix        - number of models to mix from the keep, default 0       :int
 
     prob      - probability for each digit in the rule representation to mutate, default 0.01   :float | list[float]
                 if given a list, each probability is applied for each iteration
@@ -252,9 +252,6 @@ def ga_main(start:Model, exps:list[ExpType], fixes_list:list[FixesType],
     if export_name == None:
         export_name = start.name
 
-    if mix == None:
-        mix = keep
-
     if type(prob) == float:
         prob_list = [prob] * total_iter
     elif len(prob) < total_iter:
@@ -264,13 +261,18 @@ def ga_main(start:Model, exps:list[ExpType], fixes_list:list[FixesType],
         prob_list = prob
 
     log = []
-
-    print("- - - - - iteration ", 1, " - - - - -")
     iteration = []
-    iteration.append(start)
 
+    ### First iteration ###
+
+    # this ensures that models worse than the start are not carried on.
+    # also ensures that same number of models are generated in the first iteration as in the other iterations.
+    for i in range(keep):
+        iteration.append(start)
+
+    # generate (per_iter - keep) new models
     new_model_lst = []
-    for i in range(per_iter-1):
+    for i in range(per_iter-keep):
         new_model = start.mutate(prob_list[0], edge_prob)
         new_model_lst.append(new_model)    
     if core > 1:
@@ -295,13 +297,15 @@ def ga_main(start:Model, exps:list[ExpType], fixes_list:list[FixesType],
         iteration[i].export(threshold=export_thresh)
 
     final = iteration[0]
-    print("top score :", round(final.score,2))
-    print(f"{len(final.extra_edges)} extra edges in the top model:", final.extra_edges)
-    print("complexity of the top model :", final.complexity)
+
+    print(f"iteration 1, genearted {boolmore.config.id-start.id}, top score {round(final.score,2)}/{final.max_score} ({round(final.score/final.max_score*100,1)}%)")
+
     if not final.check_constraint():
         print("ERROR: model does not follow constraints")
+
     log.append([1, final.score, final.extra_edges, final.complexity])
     
+    ### Second to last iterations ###
     for i in range(2,total_iter+1):
         print("- - - - - iteration ", i, " - - - - -")
         new_iteration = []
@@ -360,11 +364,12 @@ def ga_main(start:Model, exps:list[ExpType], fixes_list:list[FixesType],
         new_iteration = sorted(new_iteration, key=lambda x: x.score, reverse=True)
     
         final = new_iteration[0]
-        print("top score : ", round(final.score,2))
-        print(f"{len(final.extra_edges)} extra edges in the top model:", final.extra_edges)
-        print("complexity of the top model :", final.complexity)
+
+        print(f"iteration {i}, genearted {boolmore.config.id-start.id}, top score {round(final.score,2)}/{final.max_score} ({round(final.score/final.max_score*100,1)}%)")
+
         if not final.check_constraint():
             print("ERROR: model does not follow constraints")
+
         log.append([i, final.score, final.extra_edges, final.complexity])
 
         # Export models that exceed the threshold score

--- a/boolmore/score.py
+++ b/boolmore/score.py
@@ -240,6 +240,7 @@ def get_hierarchy_score(agreements:AgreeType, default_sources:dict[str,int],
                 
             if report:
                 fp.write(str(agreements[observed_node][fixes][ID]) + '\t') # type: ignore
+                # TODO: fix reporting hierarchy number
                 fp.write(str(int(math.log2(len(subset_fixes_set)))) + '\t') # type: ignore
                 for fix in fixes:
                     fp.write(str(fix[0]) + '=' + str(fix[1]) + ',') # type: ignore

--- a/boolmore/score.py
+++ b/boolmore/score.py
@@ -201,15 +201,11 @@ def get_hierarchy_score(agreements:AgreeType, default_sources:dict[str,int],
                 print(node, fixes_dict[node])
 
                 if node in default_sources:
-                    print("node is in default sources")
                     # source node value not same as default sources
                     if fixes_dict[node] != default_sources[node]:
-                        print("but the value is different")
                         hierarchy += 1
                 # non source nodes
                 else:
-                    print("node is not in default sources")
-
                     hierarchy += 1
 
             # for given fixes, find the subset fixes

--- a/boolmore/score.py
+++ b/boolmore/score.py
@@ -198,8 +198,6 @@ def get_hierarchy_score(agreements:AgreeType, default_sources:dict[str,int],
             # get the hierarchy
             hierarchy = 0
             for node in fixes_dict:
-                print(node, fixes_dict[node])
-
                 if node in default_sources:
                     # source node value not same as default sources
                     if fixes_dict[node] != default_sources[node]:

--- a/case_study/detailed_report.py
+++ b/case_study/detailed_report.py
@@ -7,7 +7,7 @@ import pyboolnet.prime_implicants as pi
 from boolmore.model import Model
 from boolmore.experiment import import_exps
 
-SETTINGS = "boolmore/case_study/data/ABA_2017_VA-KEV_del.json"
+JSON = "boolmore/case_study/data/ABA_2017_VA-KEV_del.json"
 MODEL = "boolmore/case_study/generated_models/GA_VA-KEV_del.txt"
 NAME = None
 
@@ -194,4 +194,4 @@ def get_detailed_report(json_file:str, model:str|None=None, name:str|None=None):
         print()
 
 if __name__ == '__main__':
-    get_detailed_report(SETTINGS, MODEL, NAME)
+    get_detailed_report(JSON, MODEL, NAME)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ version = "0.1.1"
 description = "Python package for refining Boolean models"
 license = { file = "LISENSE" }
 requires-python = ">=3.11"
-dependencies = ["pyboolnet @ git+https://github.com/hklarner/pyboolnet",
+dependencies = ["pyboolnet @ git+https://github.com/hklarner/pyboolnet@3.0.11",
                 "pystablemotifs"]
 
 [tool.setuptools]


### PR DESCRIPTION
First iteration now contains k (keep) copies of the start model, so that no models worse than the start model are carried on.
This also ensures that same number of models are generated in every iteration.

Also fixed the hierarchy report in the score.
Now score.py has it's __main__ where the score report for the given model is generated.

Set pyboolnet version to 3.0.11